### PR TITLE
Added Docker User

### DIFF
--- a/authentication/authentication-internal-service/Dockerfile
+++ b/authentication/authentication-internal-service/Dockerfile
@@ -9,7 +9,8 @@ ARG active_profile
 # can be passed during Docker build as build time environment for config server URL 
 ARG spring_config_url
 
-ARG bio_sdk_folder=mock/0.9
+#ARG bio_sdk_folder=mock/0.9
+ARG biosdk_zip_path
 
 # can be passed during Docker build as build time environment for hsm client zip file path
 ARG client_zip_path
@@ -38,12 +39,34 @@ ENV artifactory_url_env=${artifactory_url}
 # environment variable to pass iam_adapter url, at docker runtime
 ENV iam_adapter_url_env=${iam_adapter_url}
 
-ENV bio_sdk_folder_env=${bio_sdk_folder}
+#ENV bio_sdk_folder_env=${bio_sdk_folder}
+ENV biosdk_zip_file_path=${biosdk_zip_path}
 
 # environment variable to pass hsm client zip file path, at docker runtime
 ENV zip_file_path=${client_zip_path}
 
-ENV work_dir_env=/
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user=mosip
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_group=mosip
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_uid=1001
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_gid=1001
+
+# install packages and create user
+RUN apt-get -y update \
+&& apt-get install -y unzip \
+&& groupadd -g ${container_user_gid} ${container_user_group} \
+&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user}
+
+# set working directory for the user
+WORKDIR /home/${container_user}
+
+#ENV work_dir_env=/
 
 ENV current_module_env=authentication-internal-service
 
@@ -57,18 +80,23 @@ EXPOSE 8093
 
 EXPOSE 9010
 
-ENTRYPOINT [ "/configure_start.sh" ]
+# change permissions of file inside working dir
+RUN chown -R ${container_user}:${container_user} /home/${container_user}
+
+# select container user for all tasks
+#USER ${container_user_uid}:${container_user_gid}
+
+ENTRYPOINT [ "./configure_start.sh" ]
 
 CMD if [ "$is_glowroot_env" = "present" ]; then \
-    wget "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
-    apt-get update && apt-get install -y unzip ; \
+    wget -q --show-progress "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
     unzip glowroot.zip ; \
     rm -rf glowroot.zip ; \
     sed -i "s/<service_name>/${current_module_env}/g" glowroot/glowroot.properties ; \
-    wget "${iam_adapter_url_env}" -O kernel-auth-adapter.jar; \
+    wget -q --show-progress "${iam_adapter_url_env}" -O kernel-auth-adapter.jar; \
     java -jar -Djava.security.debug=sunpkcs11 -javaagent:glowroot/glowroot.jar -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" -Dloader.path="${loader_path_env}",./kernel-auth-adapter.jar -Dfile.encoding="UTF-8" ${current_module_env}.jar ; \
     else \
-    wget "${iam_adapter_url_env}" -O kernel-auth-adapter.jar; \
+    wget -q --show-progress "${iam_adapter_url_env}" -O kernel-auth-adapter.jar; \
     java -jar -Djava.security.debug=sunpkcs11 -Dspring.cloud.config.label="${spring_config_label_env}" -Dspring.profiles.active="${active_profile_env}" -Dspring.cloud.config.uri="${spring_config_url_env}" -Dloader.path="${loader_path_env}",./kernel-auth-adapter.jar -Dfile.encoding="UTF-8" ${current_module_env}.jar ; \
     fi
 

--- a/authentication/authentication-internal-service/Dockerfile
+++ b/authentication/authentication-internal-service/Dockerfile
@@ -13,9 +13,10 @@ ARG spring_config_url
 ARG biosdk_zip_path
 
 # can be passed during Docker build as build time environment for hsm client zip file path
-ARG client_zip_path
+#ARG client_zip_path
+ARG hsm_client_zip_path
 
-# can be passed during Docker build as build time environment for glowroot 
+# can be passed during Docker build as build time environment for glowroot
 ARG is_glowroot
 
 # can be passed during Docker build as build time environment for artifactory URL
@@ -43,7 +44,8 @@ ENV iam_adapter_url_env=${iam_adapter_url}
 ENV biosdk_zip_file_path=${biosdk_zip_path}
 
 # environment variable to pass hsm client zip file path, at docker runtime
-ENV zip_file_path=${client_zip_path}
+#ENV zip_file_path=${client_zip_path}
+ENV hsm_zip_file_path=${hsm_client_zip_path}
 
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
 ARG container_user=mosip
@@ -57,11 +59,22 @@ ARG container_user_uid=1001
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
 ARG container_user_gid=1001
 
+ARG hsm_local_dir=hsm-client
+
+ENV hsm_local_dir_name=${hsm_local_dir}
+
+ARG boisdk_local_dir=biosdk-client
+
+ENV biosdk_local_dir_name=${boisdk_local_dir}
+
 # install packages and create user
 RUN apt-get -y update \
 && apt-get install -y unzip \
 && groupadd -g ${container_user_gid} ${container_user_group} \
-&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user}
+&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user} \
+&& adduser ${container_user} sudo \
+&& echo "%sudo ALL=(ALL) NOPASSWD:/home/${container_user}/${hsm_local_dir}/install.sh" >> /etc/sudoers \
+&& echo "%sudo ALL=(ALL) NOPASSWD:/home/${container_user}/${boisdk_local_dir}/install.sh" >> /etc/sudoers
 
 # set working directory for the user
 WORKDIR /home/${container_user}
@@ -84,7 +97,7 @@ EXPOSE 9010
 RUN chown -R ${container_user}:${container_user} /home/${container_user}
 
 # select container user for all tasks
-#USER ${container_user_uid}:${container_user_gid}
+USER ${container_user_uid}:${container_user_gid}
 
 ENTRYPOINT [ "./configure_start.sh" ]
 

--- a/authentication/authentication-internal-service/configure_start.sh
+++ b/authentication/authentication-internal-service/configure_start.sh
@@ -5,24 +5,12 @@ set -e
 
 echo "Downloading pre-requisites install scripts"
 wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_biosdk.sh -O configure_biosdk.sh
-wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_softhsm.sh -O configure_softhsm.sh
+wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_hsmclient.sh -O configure_hsmclient.sh
 
 echo "Installating pre-requisites.."
-cd /
-source configure_biosdk.sh
-cd /
-source configure_softhsm.sh
+source ./configure_biosdk.sh
+source ./configure_hsmclient.sh
 
 echo "Installating pre-requisites completed."
-
-if [ ! -f "${work_dir_env}/${current_module_env}.jar" ]; then
-    echo "Copying ${current_module_env}.jar to ${work_dir_env}"
-    cp /${current_module_env}.jar "${work_dir_env}/"
-fi
-
-
-echo "Changing directory to ${work_dir_env}"
-cd "${work_dir_env}"
-
 
 exec "$@"

--- a/authentication/authentication-kyc-service/Dockerfile
+++ b/authentication/authentication-kyc-service/Dockerfile
@@ -9,7 +9,8 @@ ARG active_profile
 # can be passed during Docker build as build time environment for config server URL 
 ARG spring_config_url
 
-ARG bio_sdk_folder=mock/0.9
+#ARG bio_sdk_folder=mock/0.9
+ARG biosdk_zip_path
 
 # can be passed during Docker build as build time environment for hsm client zip file path
 ARG client_zip_path
@@ -35,12 +36,34 @@ ENV is_glowroot_env=${is_glowroot}
 # environment variable to pass artifactory url, at docker runtime
 ENV artifactory_url_env=${artifactory_url}
 
-ENV bio_sdk_folder_env=${bio_sdk_folder}
+#ENV bio_sdk_folder_env=${bio_sdk_folder}
+ENV biosdk_zip_file_path=${biosdk_zip_path}
 
 # environment variable to pass hsm client zip file path, at docker runtime
 ENV zip_file_path=${client_zip_path}
 
-ENV work_dir_env=/
+#ENV work_dir_env=/
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user=mosip
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_group=mosip
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_uid=1001
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_gid=1001
+
+# install packages and create user
+RUN apt-get -y update \
+&& apt-get install -y unzip \
+&& groupadd -g ${container_user_gid} ${container_user_group} \
+&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user}
+
+# set working directory for the user
+WORKDIR /home/${container_user}
 
 ENV current_module_env=authentication-kyc-service
 
@@ -54,11 +77,16 @@ EXPOSE 8091
 
 EXPOSE 9010
 
-ENTRYPOINT [ "/configure_start.sh" ]
+# change permissions of file inside working dir
+RUN chown -R ${container_user}:${container_user} /home/${container_user}
+
+# select container user for all tasks
+#USER ${container_user_uid}:${container_user_gid}
+
+ENTRYPOINT [ "./configure_start.sh" ]
 
 CMD if [ "$is_glowroot_env" = "present" ]; then \
-    wget "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
-    apt-get update && apt-get install -y unzip ; \
+    wget -q --show-progress "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
     unzip glowroot.zip ; \
     rm -rf glowroot.zip ; \
     sed -i "s/<service_name>/${current_module_env}/g" glowroot/glowroot.properties ; \

--- a/authentication/authentication-kyc-service/Dockerfile
+++ b/authentication/authentication-kyc-service/Dockerfile
@@ -13,7 +13,8 @@ ARG spring_config_url
 ARG biosdk_zip_path
 
 # can be passed during Docker build as build time environment for hsm client zip file path
-ARG client_zip_path
+#ARG client_zip_path
+ARG hsm_client_zip_path
 
 # can be passed during Docker build as build time environment for glowroot 
 ARG is_glowroot
@@ -40,7 +41,8 @@ ENV artifactory_url_env=${artifactory_url}
 ENV biosdk_zip_file_path=${biosdk_zip_path}
 
 # environment variable to pass hsm client zip file path, at docker runtime
-ENV zip_file_path=${client_zip_path}
+#ENV zip_file_path=${client_zip_path}
+ENV hsm_zip_file_path=${hsm_client_zip_path}
 
 #ENV work_dir_env=/
 
@@ -56,11 +58,22 @@ ARG container_user_uid=1001
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
 ARG container_user_gid=1001
 
+ARG hsm_local_dir=hsm-client
+
+ENV hsm_local_dir_name=${hsm_local_dir}
+
+ARG boisdk_local_dir=biosdk-client
+
+ENV biosdk_local_dir_name=${boisdk_local_dir}
+
 # install packages and create user
 RUN apt-get -y update \
 && apt-get install -y unzip \
 && groupadd -g ${container_user_gid} ${container_user_group} \
-&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user}
+&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user} \
+&& adduser ${container_user} sudo \
+&& echo "%sudo ALL=(ALL) NOPASSWD:/home/${container_user}/${hsm_local_dir}/install.sh" >> /etc/sudoers \
+&& echo "%sudo ALL=(ALL) NOPASSWD:/home/${container_user}/${boisdk_local_dir}/install.sh" >> /etc/sudoers
 
 # set working directory for the user
 WORKDIR /home/${container_user}
@@ -81,7 +94,7 @@ EXPOSE 9010
 RUN chown -R ${container_user}:${container_user} /home/${container_user}
 
 # select container user for all tasks
-#USER ${container_user_uid}:${container_user_gid}
+USER ${container_user_uid}:${container_user_gid}
 
 ENTRYPOINT [ "./configure_start.sh" ]
 

--- a/authentication/authentication-kyc-service/configure_start.sh
+++ b/authentication/authentication-kyc-service/configure_start.sh
@@ -5,24 +5,12 @@ set -e
 
 echo "Downloading pre-requisites install scripts"
 wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_biosdk.sh -O configure_biosdk.sh
-wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_softhsm.sh -O configure_softhsm.sh
+wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_hsmclient.sh -O configure_hsmclient.sh
 
 echo "Installating pre-requisites.."
-cd /
-source configure_biosdk.sh
-cd /
-source configure_softhsm.sh
+source ./configure_biosdk.sh
+source ./configure_hsmclient.sh
 
 echo "Installating pre-requisites completed."
-
-if [ ! -f "${work_dir_env}/${current_module_env}.jar" ]; then
-    echo "Copying ${current_module_env}.jar to ${work_dir_env}"
-    cp /${current_module_env}.jar "${work_dir_env}/"
-fi
-
-
-echo "Changing directory to ${work_dir_env}"
-cd "${work_dir_env}"
-
 
 exec "$@"

--- a/authentication/authentication-otp-service/Dockerfile
+++ b/authentication/authentication-otp-service/Dockerfile
@@ -10,7 +10,8 @@ ARG active_profile
 ARG spring_config_url
 
 # can be passed during Docker build as build time environment for hsm client zip file path
-ARG client_zip_path
+#ARG client_zip_path
+ARG hsm_client_zip_path
 
 # can be passed during Docker build as build time environment for glowroot 
 ARG is_glowroot
@@ -34,7 +35,8 @@ ENV is_glowroot_env=${is_glowroot}
 ENV artifactory_url_env=${artifactory_url}
 
 # environment variable to pass hsm client zip file path, at docker runtime
-ENV zip_file_path=${client_zip_path}
+#ENV zip_file_path=${client_zip_path}
+ENV hsm_zip_file_path=${hsm_client_zip_path}
 
 #ENV work_dir_env=/
 
@@ -50,11 +52,17 @@ ARG container_user_uid=1001
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
 ARG container_user_gid=1001
 
+ARG hsm_local_dir=hsm-client
+
+ENV hsm_local_dir_name=${hsm_local_dir}
+
 # install packages and create user
 RUN apt-get -y update \
 && apt-get install -y unzip \
 && groupadd -g ${container_user_gid} ${container_user_group} \
-&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user}
+&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user} \
+&& adduser ${container_user} sudo \
+&& echo "%sudo ALL=(ALL) NOPASSWD:/home/${container_user}/${hsm_local_dir}/install.sh" >> /etc/sudoers
 
 # set working directory for the user
 WORKDIR /home/${container_user}
@@ -75,7 +83,7 @@ EXPOSE 9010
 RUN chown -R ${container_user}:${container_user} /home/${container_user}
 
 # select container user for all tasks
-#USER ${container_user_uid}:${container_user_gid}
+USER ${container_user_uid}:${container_user_gid}
 
 ENTRYPOINT [ "./configure_start.sh" ]
 

--- a/authentication/authentication-otp-service/Dockerfile
+++ b/authentication/authentication-otp-service/Dockerfile
@@ -36,7 +36,28 @@ ENV artifactory_url_env=${artifactory_url}
 # environment variable to pass hsm client zip file path, at docker runtime
 ENV zip_file_path=${client_zip_path}
 
-ENV work_dir_env=/
+#ENV work_dir_env=/
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user=mosip
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_group=mosip
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_uid=1001
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_gid=1001
+
+# install packages and create user
+RUN apt-get -y update \
+&& apt-get install -y unzip \
+&& groupadd -g ${container_user_gid} ${container_user_group} \
+&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user}
+
+# set working directory for the user
+WORKDIR /home/${container_user}
 
 ENV current_module_env=authentication-otp-service
 
@@ -50,11 +71,16 @@ EXPOSE 8092
 
 EXPOSE 9010
 
-ENTRYPOINT [ "/configure_start.sh" ]
+# change permissions of file inside working dir
+RUN chown -R ${container_user}:${container_user} /home/${container_user}
+
+# select container user for all tasks
+#USER ${container_user_uid}:${container_user_gid}
+
+ENTRYPOINT [ "./configure_start.sh" ]
 
 CMD if [ "$is_glowroot_env" = "present" ]; then \
-    wget "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
-    apt-get update && apt-get install -y unzip ; \
+    wget -q --show-progress "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
     unzip glowroot.zip ; \
     rm -rf glowroot.zip ; \
     sed -i "s/<service_name>/${current_module_env}/g" glowroot/glowroot.properties ; \

--- a/authentication/authentication-otp-service/configure_start.sh
+++ b/authentication/authentication-otp-service/configure_start.sh
@@ -4,22 +4,11 @@
 set -e
 
 echo "Downloading pre-requisites install scripts"
-wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_softhsm.sh -O configure_softhsm.sh
+wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_hsmclient.sh -O configure_hsmclient.sh
 
 echo "Installating pre-requisites.."
-cd /
-source configure_softhsm.sh
+source ./configure_hsmclient.sh
 
 echo "Installating pre-requisites completed."
-
-if [ ! -f "${work_dir_env}/${current_module_env}.jar" ]; then
-    echo "Copying ${current_module_env}.jar to ${work_dir_env}"
-    cp /${current_module_env}.jar "${work_dir_env}/"
-fi
-
-
-echo "Changing directory to ${work_dir_env}"
-cd "${work_dir_env}"
-
 
 exec "$@"

--- a/authentication/authentication-service/Dockerfile
+++ b/authentication/authentication-service/Dockerfile
@@ -9,7 +9,8 @@ ARG active_profile
 # can be passed during Docker build as build time environment for config server URL 
 ARG spring_config_url
 
-ARG bio_sdk_folder=mock/0.9
+#ARG bio_sdk_folder=mock/0.9
+ARG biosdk_zip_path
 
 # can be passed during Docker build as build time environment for hsm client zip file path
 ARG client_zip_path
@@ -35,12 +36,34 @@ ENV is_glowroot_env=${is_glowroot}
 # environment variable to pass artifactory url, at docker runtime
 ENV artifactory_url_env=${artifactory_url}
 
-ENV bio_sdk_folder_env=${bio_sdk_folder}
+#ENV bio_sdk_folder_env=${bio_sdk_folder}
+ENV biosdk_zip_file_path=${biosdk_zip_path}
 
 # environment variable to pass hsm client zip file path, at docker runtime
 ENV zip_file_path=${client_zip_path}
 
-ENV work_dir_env=/
+#ENV work_dir_env=/
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user=mosip
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_group=mosip
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_uid=1001
+
+# can be passed during Docker build as build time environment for github branch to pickup configuration from.
+ARG container_user_gid=1001
+
+# install packages and create user
+RUN apt-get -y update \
+&& apt-get install -y unzip \
+&& groupadd -g ${container_user_gid} ${container_user_group} \
+&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user}
+
+# set working directory for the user
+WORKDIR /home/${container_user}
 
 ENV current_module_env=authentication-service
 
@@ -54,11 +77,16 @@ EXPOSE 8090
 
 EXPOSE 9010
 
-ENTRYPOINT [ "/configure_start.sh" ]
+# change permissions of file inside working dir
+RUN chown -R ${container_user}:${container_user} /home/${container_user}
+
+# select container user for all tasks
+#USER ${container_user_uid}:${container_user_gid}
+
+ENTRYPOINT [ "./configure_start.sh" ]
 
 CMD if [ "$is_glowroot_env" = "present" ]; then \
-    wget "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
-    apt-get update && apt-get install -y unzip ; \
+    wget -q --show-progress "${artifactory_url_env}"/artifactory/libs-release-local/io/mosip/testing/glowroot.zip ; \
     unzip glowroot.zip ; \
     rm -rf glowroot.zip ; \
     sed -i "s/<service_name>/${current_module_env}/g" glowroot/glowroot.properties ; \

--- a/authentication/authentication-service/Dockerfile
+++ b/authentication/authentication-service/Dockerfile
@@ -13,7 +13,8 @@ ARG spring_config_url
 ARG biosdk_zip_path
 
 # can be passed during Docker build as build time environment for hsm client zip file path
-ARG client_zip_path
+#ARG client_zip_path
+ARG hsm_client_zip_path
 
 # can be passed during Docker build as build time environment for glowroot 
 ARG is_glowroot
@@ -40,7 +41,8 @@ ENV artifactory_url_env=${artifactory_url}
 ENV biosdk_zip_file_path=${biosdk_zip_path}
 
 # environment variable to pass hsm client zip file path, at docker runtime
-ENV zip_file_path=${client_zip_path}
+#ENV zip_file_path=${client_zip_path}
+ENV hsm_zip_file_path=${hsm_client_zip_path}
 
 #ENV work_dir_env=/
 
@@ -56,11 +58,22 @@ ARG container_user_uid=1001
 # can be passed during Docker build as build time environment for github branch to pickup configuration from.
 ARG container_user_gid=1001
 
+ARG hsm_local_dir=hsm-client
+
+ENV hsm_local_dir_name=${hsm_local_dir}
+
+ARG boisdk_local_dir=biosdk-client
+
+ENV biosdk_local_dir_name=${boisdk_local_dir}
+
 # install packages and create user
 RUN apt-get -y update \
 && apt-get install -y unzip \
 && groupadd -g ${container_user_gid} ${container_user_group} \
-&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user}
+&& useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/sh -m ${container_user} \
+&& adduser ${container_user} sudo \
+&& echo "%sudo ALL=(ALL) NOPASSWD:/home/${container_user}/${hsm_local_dir}/install.sh" >> /etc/sudoers \
+&& echo "%sudo ALL=(ALL) NOPASSWD:/home/${container_user}/${boisdk_local_dir}/install.sh" >> /etc/sudoers
 
 # set working directory for the user
 WORKDIR /home/${container_user}
@@ -81,7 +94,7 @@ EXPOSE 9010
 RUN chown -R ${container_user}:${container_user} /home/${container_user}
 
 # select container user for all tasks
-#USER ${container_user_uid}:${container_user_gid}
+USER ${container_user_uid}:${container_user_gid}
 
 ENTRYPOINT [ "./configure_start.sh" ]
 

--- a/authentication/authentication-service/configure_start.sh
+++ b/authentication/authentication-service/configure_start.sh
@@ -5,24 +5,12 @@ set -e
 
 echo "Downloading pre-requisites install scripts"
 wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_biosdk.sh -O configure_biosdk.sh
-wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_softhsm.sh -O configure_softhsm.sh
+wget --no-check-certificate --no-cache --no-cookies $artifactory_url_env/artifactory/libs-release-local/deployment/docker/id-authentication/configure_hsmclient.sh -O configure_hsmclient.sh
 
 echo "Installating pre-requisites.."
-cd /
-source configure_biosdk.sh
-cd /
-source configure_softhsm.sh
+source ./configure_biosdk.sh
+source ./configure_hsmclient.sh
 
 echo "Installating pre-requisites completed."
-
-if [ ! -f "${work_dir_env}/${current_module_env}.jar" ]; then
-    echo "Copying ${current_module_env}.jar to ${work_dir_env}"
-    cp /${current_module_env}.jar "${work_dir_env}/"
-fi
-
-
-echo "Changing directory to ${work_dir_env}"
-cd "${work_dir_env}"
-
 
 exec "$@"

--- a/docker/configure_biosdk.sh
+++ b/docker/configure_biosdk.sh
@@ -33,6 +33,7 @@ fi
 echo "Attempting to install"
 cd ./$DIR_NAME && chmod +x install.sh && source ./install.sh
 echo "Installation complete"
+cd ..
 
 echo "Changing Docker User"
 chown -R ${container_user}:${container_user} /home/${container_user}

--- a/docker/configure_biosdk.sh
+++ b/docker/configure_biosdk.sh
@@ -12,7 +12,7 @@ echo "Downloaded $artifactory_url_env/$zip_path"
 
 FILE_NAME=${zip_path##*/}
 
-DIR_NAME=biosdk-client
+DIR_NAME=$biosdk_local_dir_name
 
 has_parent=$(zipinfo -1 "$FILE_NAME" | awk '{split($NF,a,"/");print a[1]}' | sort -u | wc -l)
 if test "$has_parent" -eq 1; then
@@ -31,12 +31,8 @@ else
 fi
 
 echo "Attempting to install"
-cd ./$DIR_NAME && chmod +x install.sh && source ./install.sh
+cd ./$DIR_NAME && chmod +x install.sh && sudo source ./install.sh
 echo "Installation complete"
 cd ..
-
-echo "Changing Docker User"
-chown -R ${container_user}:${container_user} /home/${container_user}
-su $container_user
 
 exec "$@"

--- a/docker/configure_hsmclient.sh
+++ b/docker/configure_hsmclient.sh
@@ -3,16 +3,18 @@
 #installs the pkcs11 libraries.
 set -e
 
-DEFAULT_ZIP_PATH=artifactory/libs-release-local/biosdk/mock/0.9/biosdk.zip
-[ -z "$biosdk_zip_file_path" ] && zip_path="$DEFAULT_ZIP_PATH" || zip_path="$biosdk_zip_file_path"
+DEFAULT_ZIP_PATH=artifactory/libs-release-local/hsm/client.zip
+[ -z "$zip_file_path" ] && zip_path="$DEFAULT_ZIP_PATH" || zip_path="$zip_file_path"
 
-echo "Download the biosdk from $artifactory_url_env"
+echo "Download the client from $artifactory_url_env"
+echo "Zip File Path: $zip_path"
+
 wget -q --show-progress "$artifactory_url_env/$zip_path"
 echo "Downloaded $artifactory_url_env/$zip_path"
 
 FILE_NAME=${zip_path##*/}
 
-DIR_NAME=biosdk-client
+DIR_NAME=hsm-client
 
 has_parent=$(zipinfo -1 "$FILE_NAME" | awk '{split($NF,a,"/");print a[1]}' | sort -u | wc -l)
 if test "$has_parent" -eq 1; then
@@ -31,7 +33,7 @@ else
 fi
 
 echo "Attempting to install"
-cd ./$DIR_NAME && chmod +x install.sh && source ./install.sh
+cd ./$DIR_NAME && chmod +x install.sh && ./install.sh
 echo "Installation complete"
 
 echo "Changing Docker User"

--- a/docker/configure_hsmclient.sh
+++ b/docker/configure_hsmclient.sh
@@ -35,6 +35,7 @@ fi
 echo "Attempting to install"
 cd ./$DIR_NAME && chmod +x install.sh && ./install.sh
 echo "Installation complete"
+cd ..
 
 echo "Changing Docker User"
 chown -R ${container_user}:${container_user} /home/${container_user}

--- a/docker/configure_hsmclient.sh
+++ b/docker/configure_hsmclient.sh
@@ -4,7 +4,7 @@
 set -e
 
 DEFAULT_ZIP_PATH=artifactory/libs-release-local/hsm/client.zip
-[ -z "$zip_file_path" ] && zip_path="$DEFAULT_ZIP_PATH" || zip_path="$zip_file_path"
+[ -z "$hsm_zip_file_path" ] && zip_path="$DEFAULT_ZIP_PATH" || zip_path="$hsm_zip_file_path"
 
 echo "Download the client from $artifactory_url_env"
 echo "Zip File Path: $zip_path"
@@ -14,7 +14,7 @@ echo "Downloaded $artifactory_url_env/$zip_path"
 
 FILE_NAME=${zip_path##*/}
 
-DIR_NAME=hsm-client
+DIR_NAME=$hsm_local_dir_name
 
 has_parent=$(zipinfo -1 "$FILE_NAME" | awk '{split($NF,a,"/");print a[1]}' | sort -u | wc -l)
 if test "$has_parent" -eq 1; then
@@ -33,12 +33,9 @@ else
 fi
 
 echo "Attempting to install"
-cd ./$DIR_NAME && chmod +x install.sh && ./install.sh
+cd ./$DIR_NAME && chmod +x install.sh && sudo ./install.sh
 echo "Installation complete"
 cd ..
 
-echo "Changing Docker User"
-chown -R ${container_user}:${container_user} /home/${container_user}
-su $container_user
 
 exec "$@"


### PR DESCRIPTION
Issue: 1. As per security standard, Container should run with a non-root user.
2. In a few cases, while installation of biosdk and hsm client, zip name and directory inside the zip file do not have the same name. Which cause the failure of the installation.

Fix 1. Added Docker user to run as a non-root user. Changed the working directory of the user.
2.  Modified the biosdk installation script and hsm client installation script to handle errors dynamically. 
3. Added one new variable to handle the name of biosdk zip file at runtime. (biosdk_zip_path)