### PR TITLE
[MOSIP-15390] Handling null kyc languages. 

### DIFF
--- a/authentication/authentication-common/src/main/java/io/mosip/authentication/common/service/filter/IdAuthFilter.java
+++ b/authentication/authentication-common/src/main/java/io/mosip/authentication/common/service/filter/IdAuthFilter.java
@@ -439,7 +439,7 @@ public class IdAuthFilter extends BaseAuthFilter {
 	 */
 	private Set<String> validateAndGetKycLanguages(Set<String> kycLanguages) {
 		Set<String> systemSupportedLanguages = getSystemSupportedLanguageCodes();
-		if(kycLanguages.stream().anyMatch(systemSupportedLanguages::contains)) {
+		if(kycLanguages != null && kycLanguages.stream().anyMatch(systemSupportedLanguages::contains)) {
 			return kycLanguages;
 		}
 		return systemSupportedLanguages;


### PR DESCRIPTION
Kyc Languages are not present considering system supported languages.
system Supported languages = mandatory languages + optional languages. 