### PR TITLE
Mosip 26742 hash logic compatibility 1 (#1008)

### DIFF
--- a/authentication/authentication-common/src/main/java/io/mosip/authentication/common/service/transaction/manager/IdAuthSecurityManager.java
+++ b/authentication/authentication-common/src/main/java/io/mosip/authentication/common/service/transaction/manager/IdAuthSecurityManager.java
@@ -178,7 +178,7 @@ public class IdAuthSecurityManager {
 	@Autowired
     private KeymanagerUtil keymanagerUtil;
 	
-	@Value("mosip.ida.idhash.legacy-salt-selection-enabled:false")
+	@Value("${mosip.ida.idhash.legacy-salt-selection-enabled:false}")
 	private boolean legacySaltSelectionEnabled;
 	
 	@Autowired


### PR DESCRIPTION
* Added support for legacy method of hashing

* Test fixes

* Handled salt missing when newhash calculation

* Review comment fixes

* Updated conditions and added logging

* Fixed value annotation

---------