### PR TITLE
[BUGFIX] [ES-176]

### DIFF
--- a/authentication/esignet-integration-impl/src/main/java/io/mosip/authentication/esignet/integration/service/IdaAuthenticatorImpl.java
+++ b/authentication/esignet-integration-impl/src/main/java/io/mosip/authentication/esignet/integration/service/IdaAuthenticatorImpl.java
@@ -165,7 +165,11 @@ public class IdaAuthenticatorImpl implements Authenticator {
             idaKycExchangeRequest.setRequestTime(HelperService.getUTCDateTime());
             idaKycExchangeRequest.setTransactionID(kycExchangeDto.getTransactionId());
             idaKycExchangeRequest.setKycToken(kycExchangeDto.getKycToken());
-            idaKycExchangeRequest.setConsentObtained(kycExchangeDto.getAcceptedClaims());
+	    if (!CollectionUtils.isEmpty(kycExchangeDto.getAcceptedClaims())) {
+                idaKycExchangeRequest.setConsentObtained(kycExchangeDto.getAcceptedClaims());
+            } else {
+                idaKycExchangeRequest.setConsentObtained(List.of("sub"));
+            }
             idaKycExchangeRequest.setLocales(Arrays.asList(kycExchangeDto.getClaimsLocales()));
             idaKycExchangeRequest.setRespType(kycExchangeDto.getUserInfoResponseType()); //may be either JWT or JWE
             idaKycExchangeRequest.setIndividualId(kycExchangeDto.getIndividualId());

--- a/authentication/esignet-integration-impl/src/test/java/io/mosip/authentication/esignet/integration/service/IdaAuthenticatorImplTest.java
+++ b/authentication/esignet-integration-impl/src/test/java/io/mosip/authentication/esignet/integration/service/IdaAuthenticatorImplTest.java
@@ -248,6 +248,41 @@ public class IdaAuthenticatorImplTest {
 		Assert.assertEquals(idaKycExchangeResponse.getEncryptedKyc(), kycExchangeResult.getEncryptedKyc());
 	}
 
+
+	@Test
+	public void doKycExchange_withValidDetailsEmptyAcceptedClaims_thenPass() throws Exception {
+		KycExchangeDto kycExchangeDto = new KycExchangeDto();
+		kycExchangeDto.setIndividualId("IND1234");
+		kycExchangeDto.setKycToken("KYCT123");
+		kycExchangeDto.setTransactionId("TRAN123");
+		List<String> acceptedClaims = List.of();
+		kycExchangeDto.setAcceptedClaims(acceptedClaims);
+		String[] claimsLacales = new String[] { "claims", "locales" };
+		kycExchangeDto.setClaimsLocales(claimsLacales);
+
+		Mockito.when(mapper.writeValueAsString(Mockito.any())).thenReturn("value");
+
+		IdaKycExchangeResponse idaKycExchangeResponse = new IdaKycExchangeResponse();
+		idaKycExchangeResponse.setEncryptedKyc("ENCRKYC123");
+
+		IdaResponseWrapper<IdaKycExchangeResponse> idaResponseWrapper = new IdaResponseWrapper<>();
+		idaResponseWrapper.setResponse(idaKycExchangeResponse);
+		idaResponseWrapper.setTransactionID("TRAN123");
+		idaResponseWrapper.setVersion("VER1");
+
+		ResponseEntity<IdaResponseWrapper<IdaKycExchangeResponse>> responseEntity = new ResponseEntity<IdaResponseWrapper<IdaKycExchangeResponse>>(
+				idaResponseWrapper, HttpStatus.OK);
+
+		Mockito.when(restTemplate.exchange(Mockito.<RequestEntity<Void>>any(),
+						Mockito.<ParameterizedTypeReference<IdaResponseWrapper<IdaKycExchangeResponse>>>any()))
+				.thenReturn(responseEntity);
+
+		KycExchangeResult kycExchangeResult = idaAuthenticatorImpl.doKycExchange("relyingPartyId", "clientId",
+				kycExchangeDto);
+
+		Assert.assertEquals(idaKycExchangeResponse.getEncryptedKyc(), kycExchangeResult.getEncryptedKyc());
+	}
+
 	@Test
 	public void doKycExchange_withInvalidDetails_thenFail() throws Exception {
 		KycExchangeDto kycExchangeDto = new KycExchangeDto();


### PR DESCRIPTION
[ES-176]
Handles the scenario when no claims are accepted from a set of optional claims "sub" parameter is added to consented claims  if it is empty

[ES-176]: https://mosip.atlassian.net/browse/ES-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ