### PR TITLE
iat validation corrected

### DIFF
--- a/authentication/authentication-common/src/main/java/io/mosip/authentication/common/service/util/KeyBindedTokenMatcherUtil.java
+++ b/authentication/authentication-common/src/main/java/io/mosip/authentication/common/service/util/KeyBindedTokenMatcherUtil.java
@@ -169,7 +169,7 @@ public class KeyBindedTokenMatcherUtil {
         LocalDateTime issuedLDT = DateUtils.parseDateToLocalDateTime(issuedDateTime);
 		long diffSeconds = ChronoUnit.SECONDS.between(issuedLDT, currentTime);
         
-		if (issuedDateTime != null && diffSeconds > 0 && diffSeconds <= iatAdjSeconds) {
+		if (issuedDateTime != null && diffSeconds >= 0 && diffSeconds <= iatAdjSeconds) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Got an error: "IDA-KBT-002", "Signed token issued at (iat) is not in allowed time range."

requestTime: "2023-07-18T21:56:14.528Z" (3:26:14)
"iat": 1689717374 ( 3:26:14)

The validation isIatWithinAllowedTime is failing for condition diffSeconds > 0.