### PR TITLE
MOSIP-39719 - Added a log level for the commons classes

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testrunner/MosipTestRunner.java
@@ -38,6 +38,7 @@ import io.mosip.testrig.apirig.utils.CertificateGenerationUtil;
 import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.ConfigManager;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.GlobalMethods;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
 import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeyCloakUserAndAPIKeyGeneration;
@@ -82,6 +83,7 @@ public class MosipTestRunner {
 			IdAuthConfigManager.init();
 			suiteSetup(getRunType());
 			SkipTestCaseHandler.loadTestcaseToBeSkippedList("testCaseSkippedList.txt");
+			GlobalMethods.setModuleNameAndReCompilePattern(IdAuthConfigManager.getproperty("moduleNamePattern"));
 			setLogLevels();
 
 			// For now we are not doing health check for qa-115.

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testrunner/MosipTestRunner.java
@@ -24,6 +24,7 @@ import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 
 import io.mosip.testrig.apirig.auth.utils.IdAuthConfigManager;
+import io.mosip.testrig.apirig.auth.utils.IdAuthenticationUtil;
 import io.mosip.testrig.apirig.dataprovider.BiometricDataProvider;
 import io.mosip.testrig.apirig.dbaccess.DBManager;
 import io.mosip.testrig.apirig.report.EmailableReport;
@@ -38,6 +39,7 @@ import io.mosip.testrig.apirig.utils.CertsUtil;
 import io.mosip.testrig.apirig.utils.ConfigManager;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.JWKKeyUtil;
+import io.mosip.testrig.apirig.utils.KernelAuthentication;
 import io.mosip.testrig.apirig.utils.KeyCloakUserAndAPIKeyGeneration;
 import io.mosip.testrig.apirig.utils.KeycloakUserManager;
 import io.mosip.testrig.apirig.utils.MispPartnerAndLicenseKeyGeneration;
@@ -67,12 +69,8 @@ public class MosipTestRunner {
 	public static void main(String[] arg) {
 
 		try {
-
-			Map<String, String> envMap = System.getenv();
-			LOGGER.info("** ------------- Get ALL ENV varibales --------------------------------------------- **");
-			for (String envName : envMap.keySet()) {
-				LOGGER.info(String.format("ENV %s = %s%n", envName, envMap.get(envName)));
-			}
+			LOGGER.info("** ------------- API Test Rig Run Started --------------------------------------------- **");
+			
 			BaseTestCase.setRunContext(getRunType(), jarUrl);
 			ExtractResource.removeOldMosipTestTestResource();
 			if (getRunType().equalsIgnoreCase("JAR")) {
@@ -172,6 +170,9 @@ public class MosipTestRunner {
 		MispPartnerAndLicenseKeyGeneration.setLogLevel();
 		JWKKeyUtil.setLogLevel();
 		CertsUtil.setLogLevel();
+		KernelAuthentication.setLogLevel();
+		BaseTestCase.setLogLevel();
+		IdAuthenticationUtil.setLogLevel();
 	}
 
 	/**

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/utils/IdAuthConfigManager.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/utils/IdAuthConfigManager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 import io.mosip.testrig.apirig.auth.testrunner.MosipTestRunner;
@@ -13,6 +14,9 @@ public class IdAuthConfigManager extends ConfigManager{
 	private static final Logger LOGGER = Logger.getLogger(IdAuthConfigManager.class);
 	
 	public static void init() {
+		Logger configManagerLogger = Logger.getLogger(ConfigManager.class);
+		configManagerLogger.setLevel(Level.WARN);
+		
 		Map<String, Object> moduleSpecificPropertiesMap = new HashMap<>();
 		// Load scope specific properties
 		try {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/utils/IdAuthenticationUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/utils/IdAuthenticationUtil.java
@@ -1,5 +1,6 @@
 package io.mosip.testrig.apirig.auth.utils;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.testng.SkipException;
@@ -15,6 +16,13 @@ import io.mosip.testrig.apirig.utils.SkipTestCaseHandler;
 public class IdAuthenticationUtil extends AdminTestUtil {
 
 	private static final Logger logger = Logger.getLogger(IdAuthenticationUtil.class);
+	
+	public static void setLogLevel() {
+		if (IdAuthConfigManager.IsDebugEnabled())
+			logger.setLevel(Level.ALL);
+		else
+			logger.setLevel(Level.ERROR);
+	}
 	
 	public static String isTestCaseValidForExecution(TestCaseDTO testCaseDTO) {
 		String testCaseName = testCaseDTO.getTestCaseName();


### PR DESCRIPTION
The setLogLevel method was added to the commons classes to prevent sensitive information, like secrets, from being printed in the console logs.