### PR TITLE
MOSIP-40258: Standardized XSS Exception Handling in apitest-auth Module 

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/AddIdentity.java
@@ -43,6 +43,7 @@ import io.mosip.testrig.apirig.utils.KeycloakUserManager;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.RestClient;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class AddIdentity extends IdAuthenticationUtil implements ITest {
@@ -89,7 +90,7 @@ public class AddIdentity extends IdAuthenticationUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/BioAuth.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/BioAuth.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.EncryptionDecrptionUtil;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class BioAuth extends IdAuthenticationUtil implements ITest {
@@ -73,7 +74,7 @@ public class BioAuth extends IdAuthenticationUtil implements ITest {
 		return getYmlTestData(ymlFile);
 	}
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 	

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/DemoAuth.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/DemoAuth.java
@@ -33,6 +33,7 @@ import io.mosip.testrig.apirig.utils.EncryptionDecrptionUtil;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class DemoAuth extends IdAuthenticationUtil implements ITest {
@@ -72,7 +73,7 @@ public class DemoAuth extends IdAuthenticationUtil implements ITest {
 	}
 	
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {		
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {		
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/DemoAuthSimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/DemoAuthSimplePostForAutoGenId.java
@@ -41,6 +41,7 @@ import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.RestClient;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class DemoAuthSimplePostForAutoGenId extends IdAuthenticationUtil implements ITest {
@@ -92,7 +93,7 @@ public class DemoAuthSimplePostForAutoGenId extends IdAuthenticationUtil impleme
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException {
+			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		String[] kycFields = testCaseDTO.getKycFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/GetWithParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/GetWithParam.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class GetWithParam extends IdAuthenticationUtil implements ITest {
@@ -78,7 +79,7 @@ public class GetWithParam extends IdAuthenticationUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/GetWithParamForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/GetWithParamForAutoGenId.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class GetWithParamForAutoGenId extends IdAuthenticationUtil implements ITest {
@@ -80,7 +81,7 @@ public class GetWithParamForAutoGenId extends IdAuthenticationUtil implements IT
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/MultiFactorAuthNew.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/MultiFactorAuthNew.java
@@ -34,6 +34,7 @@ import io.mosip.testrig.apirig.utils.EncryptionDecrptionUtil;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class MultiFactorAuthNew extends IdAuthenticationUtil implements ITest {
@@ -73,7 +74,7 @@ public class MultiFactorAuthNew extends IdAuthenticationUtil implements ITest {
 	}
 	
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/OtpAuthNew.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/OtpAuthNew.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.FileUtil;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class OtpAuthNew extends IdAuthenticationUtil implements ITest {
@@ -72,7 +73,7 @@ public class OtpAuthNew extends IdAuthenticationUtil implements ITest {
 	}
 	
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {		
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {		
 		testCaseName = testCaseDTO.getTestCaseName(); 
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PatchWithBodyWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PatchWithBodyWithOtpGenerate.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PatchWithBodyWithOtpGenerate extends IdAuthenticationUtil implements ITest {
@@ -75,7 +76,7 @@ public class PatchWithBodyWithOtpGenerate extends IdAuthenticationUtil implement
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithAutogenIdWithOtpGenerate extends IdAuthenticationUtil implements ITest {
@@ -83,7 +84,7 @@ public class PostWithAutogenIdWithOtpGenerate extends IdAuthenticationUtil imple
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NumberFormatException, InterruptedException {
+			throws AuthenticationTestException, AdminTestException, NumberFormatException, InterruptedException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithBodyWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithBodyWithOtpGenerate.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithBodyWithOtpGenerate extends IdAuthenticationUtil implements ITest {
@@ -77,7 +78,7 @@ public class PostWithBodyWithOtpGenerate extends IdAuthenticationUtil implements
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithOnlyPathParam.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithOnlyPathParam.java
@@ -32,6 +32,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class PostWithOnlyPathParam extends IdAuthenticationUtil implements ITest {
@@ -77,7 +78,7 @@ public class PostWithOnlyPathParam extends IdAuthenticationUtil implements ITest
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		String[] templateFields = testCaseDTO.getTemplateFields();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/SimplePost.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/SimplePost.java
@@ -33,6 +33,7 @@ import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePost extends IdAuthenticationUtil implements ITest {
@@ -79,7 +80,7 @@ public class SimplePost extends IdAuthenticationUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		auditLogCheck = testCaseDTO.isAuditLogCheck();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/SimplePostForAutoGenId.java
@@ -33,6 +33,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class SimplePostForAutoGenId extends IdAuthenticationUtil implements ITest {
@@ -83,7 +84,7 @@ public class SimplePostForAutoGenId extends IdAuthenticationUtil implements ITes
 	 */
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO)
-			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException {
+			throws AuthenticationTestException, AdminTestException, NoSuchAlgorithmException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		if (HealthChecker.signalTerminateExecution) {

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/UpdateDraft.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/UpdateDraft.java
@@ -31,6 +31,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class UpdateDraft extends IdAuthenticationUtil implements ITest {
@@ -77,7 +78,7 @@ public class UpdateDraft extends IdAuthenticationUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		testCaseDTO.setInputTemplate(AdminTestUtil.generateHbsForUpdateDraft());

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/UpdateIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/UpdateIdentity.java
@@ -36,6 +36,7 @@ import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
+import io.mosip.testrig.apirig.utils.SecurityXSSException;
 import io.restassured.response.Response;
 
 public class UpdateIdentity extends IdAuthenticationUtil implements ITest {
@@ -89,14 +90,14 @@ public class UpdateIdentity extends IdAuthenticationUtil implements ITest {
 	 * @throws AdminTestException
 	 */
 	@Test(dataProvider = "testcaselist")
-	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = testCaseDTO.getTestCaseName();
 		testCaseName = IdAuthenticationUtil.isTestCaseValidForExecution(testCaseDTO);
 		updateIdentity(testCaseDTO);
 
 	}
 
-	public void updateIdentity(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException {
+	public void updateIdentity(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 
 		testCaseName = testCaseDTO.getTestCaseName();
 		if (HealthChecker.signalTerminateExecution) {


### PR DESCRIPTION
Integrated SecurityXSSException in the apitest-auth module to standardize XSS-related error handling. This ensures consistent exception throwing across the application wherever XSS protection checks fail. Improves security and maintainability by centralizing exception logic.