### PR TITLE
MOSIP-43191: Removed the testcases from skipped list which are fixed

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-auth</name>
 	<description>Parent project of MOSIP Id Authentication apitests</description>
 	<url>https://github.com/mosip/id-authentication</url>
-	<version>1.2.1.2-beta.1</version>
+	<version>1.2.1.2-SNAPSHOT</version>
 
 	<licenses>
 		<license>
@@ -72,7 +72,7 @@
 		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
 
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
-		<fileName>apitest-auth-1.2.1.2-beta.1-jar-with-dependencies</fileName>
+		<fileName>apitest-auth-1.2.1.2-SNAPSHOT-jar-with-dependencies</fileName>
 	</properties>
 
 	<dependencies>

--- a/api-test/src/main/resources/testCaseSkippedList.txt
+++ b/api-test/src/main/resources/testCaseSkippedList.txt
@@ -1,15 +1,6 @@
 ##### JIRA number;testcase 
 #MOSIP-12456------test_case_name
-MOSIP-37285------auth_BioAuth_With_Deactivated_UIN
-MOSIP-37285------auth_EkycBio_Face_With_Deactivated_uin
-MOSIP-41019------auth_EkycOtp_Auth_With_Invalid_Empty_Timestamp_UIN_Neg
-MOSIP-37285------auth_EkycOtp_Auth_With_deactivate_UIN_Smoke
 MOSIP-41020------auth_BlockHotlistAPI_when_expiry_time_old_incorrect
-MOSIP-37285------auth_DemoAuth_with_Deactivated_UIN
-MOSIP-32753------auth_DemoAuth_with_age_below_calculated_value_Neg
-MOSIP-32753------auth_DemoAuth_with_negative_age_value_Neg
-MOSIP-32753------auth_DemoAuth_with_zero_age_value_Neg
-MOSIP-37285------auth_EkycDemo_Auth_With_Deactivated_UIN
 MOSIP-41021------auth_SendOTP_toBlockedVID_Neg
 MOSIP-41021------auth_SendOTP_to_DeactivatedUIN_Neg
 MOSIP-41021------auth_SendOTP_to_LockedphoneAndEmail_valid_uin_Neg


### PR DESCRIPTION
Removed from KNOWN ISSUES in release-1.2.1.x branch for fixed IDA automation failures for auth for deactivated UIN, age authentication as demo auth.