### PR TITLE
MOSIP-43580: Removed Keycloak user cleanup calls.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testrunner/MosipTestRunner.java
@@ -143,8 +143,6 @@ public class MosipTestRunner {
 		KeycloakUserManager.removeUser();
 		KeycloakUserManager.removeKeyCloakUser(PartnerRegistration.partnerId);
 		KeycloakUserManager.removeKeyCloakUser(PartnerRegistration.ekycPartnerId);
-		KeycloakUserManager.removeKeyCloakUser(PartnerRegistration.deviceOrganizationName);
-		KeycloakUserManager.removeKeyCloakUser(PartnerRegistration.ftmOrganizationName);
 		KeycloakUserManager.closeKeycloakInstance();
 
 		OTPListener.bTerminate = true;


### PR DESCRIPTION
Removed the two Keycloak user removal calls for **deviceOrganizationName** and **ftmOrganizationName** as they are not created in keycloak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure cleanup procedures.

**Note:** This change affects internal testing only and has no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->