### PR TITLE
[MOSIP-43787] Added index on credential_event_store for status filtering from v1.2.1.2 upgrade scripts, rollback & upgrade from 1.3.0-beta.1 to 1.3.0.

### DIFF
--- a/db_scripts/mosip_ida/ddl/ida-credential_event_store.sql
+++ b/db_scripts/mosip_ida/ddl/ida-credential_event_store.sql
@@ -81,3 +81,5 @@ COMMENT ON COLUMN ida.credential_event_store.is_deleted IS 'IS_Deleted : Flag to
 COMMENT ON COLUMN ida.credential_event_store.del_dtimes IS 'Deleted DateTimestamp : Date and Timestamp when the record is soft deleted with is_deleted=TRUE';
 -- ddl-end --
 
+CREATE INDEX IF NOT EXISTS cred_event_store_status_cr_dtimes ON ida.credential_event_store USING btree (status_code desc, retry_count, cr_dtimes) WHERE status_code in ('NEW','FAILED');
+

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
@@ -1,7 +1,6 @@
 -- ------------------------------------------------------------------------------------------
 -- Rollback script for Migrating Spring batch version back from 5.0 as part of Java 21 Migration.
 -- ------------------------------------------------------------------------------------------
--- Below script required to upgrade from 1.3.0-B2 to 1.3.0
 \c mosip_ida
 TRUNCATE TABLE batch_job_execution CASCADE;
 TRUNCATE TABLE batch_job_execution_context CASCADE;

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
@@ -257,8 +257,3 @@ DROP INDEX IF EXISTS idx_cred_evt_pending;
 DROP INDEX CONCURRENTLY IF EXISTS idx_hotlist_idhash_idtype;
 DROP INDEX CONCURRENTLY IF EXISTS idx_hotlist_active;
 DROP INDEX IF EXISTS idx_otp_txn_ref_status_gen;
-
-
--- Below script required to rollback from 1.3.0-B2 to 1.3.0-B1
--- ca_cert_type column is removed/deleted from ca_cert_store table --
-ALTER TABLE IF EXISTS ida.ca_cert_store DROP COLUMN IF EXISTS ca_cert_type;

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
@@ -42,6 +42,7 @@ DROP INDEX IF EXISTS idx_job_key;
 ----------ca_cert_store-rollback- db script-------------
 ALTER TABLE IF EXISTS ida.ca_cert_store DROP COLUMN IF EXISTS ca_cert_type;
 
+-- Below script required to rollback from 1.3.0-beta.2 to 1.3.0.
 -- Rollback autovacuum settings to defaults
 ALTER TABLE anonymous_profile RESET (
     autovacuum_vacuum_scale_factor,

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
@@ -39,6 +39,7 @@ ALTER TABLE BATCH_JOB_EXECUTION ADD COLUMN JOB_CONFIGURATION_LOCATION VARCHAR(25
 DROP INDEX IF EXISTS idx_job_name;
 DROP INDEX IF EXISTS idx_job_key;
 
+-- Below script required to rollback from 1.3.0-beta.1 to 1.3.0.
 ----------ca_cert_store-rollback- db script-------------
 ALTER TABLE IF EXISTS ida.ca_cert_store DROP COLUMN IF EXISTS ca_cert_type;
 

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_rollback.sql
@@ -38,7 +38,6 @@ ALTER TABLE BATCH_JOB_EXECUTION ADD COLUMN JOB_CONFIGURATION_LOCATION VARCHAR(25
 DROP INDEX IF EXISTS idx_job_name;
 DROP INDEX IF EXISTS idx_job_key;
 
--- Below script required to rollback from 1.3.0-beta.1 to 1.3.0.
 ----------ca_cert_store-rollback- db script-------------
 ALTER TABLE IF EXISTS ida.ca_cert_store DROP COLUMN IF EXISTS ca_cert_type;
 

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_upgrade.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_upgrade.sql
@@ -18,7 +18,6 @@ ALTER TABLE BATCH_JOB_EXECUTION DROP COLUMN JOB_CONFIGURATION_LOCATION;
 CREATE INDEX IF NOT EXISTS idx_job_name ON BATCH_JOB_INSTANCE(JOB_NAME);
 CREATE INDEX IF NOT EXISTS idx_job_key ON BATCH_JOB_INSTANCE(JOB_KEY);
 
--- Below script required to upgraded from 1.3.0-beta.1 to 1.3.0
 --------ca_cert_store-upgrade-db script------------
 ALTER TABLE IF EXISTS ida.ca_cert_store ADD COLUMN ca_cert_type character varying(25);
 
@@ -278,7 +277,3 @@ ALTER TABLE uin_hash_salt SET (
     autovacuum_analyze_scale_factor = 0.1,
     autovacuum_analyze_threshold = 50
 );
-
--- Below script required to upgrade from 1.3.0-B1 to 1.3.0-B2
--- ca_cert_type column is added to the ca_cert_store table --
-ALTER TABLE IF EXISTS ida.ca_cert_store ADD COLUMN ca_cert_type character varying(25);

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_upgrade.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_upgrade.sql
@@ -1,7 +1,6 @@
 -- ------------------------------------------------------------------------------------------
 -- Upgrade script for Migrating Spring batch version to 5.0 as part of Java 21 Migration.
 -- ------------------------------------------------------------------------------------------
--- Below script required to upgrade from 1.3.0-B2 to 1.3.0
 \c mosip_ida
 ALTER TABLE BATCH_STEP_EXECUTION ADD CREATE_TIME TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00';
 ALTER TABLE BATCH_STEP_EXECUTION ALTER COLUMN START_TIME DROP NOT NULL;

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_upgrade.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_upgrade.sql
@@ -21,7 +21,7 @@ CREATE INDEX IF NOT EXISTS idx_job_key ON BATCH_JOB_INSTANCE(JOB_KEY);
 --------ca_cert_store-upgrade-db script------------
 ALTER TABLE IF EXISTS ida.ca_cert_store ADD COLUMN ca_cert_type character varying(25);
 
-
+-- Below script required to upgrade from 1.3.0-beta.2 to 1.3.0.
 -- Optimize autovacuum for anonymous_profile to handle moderate updates
 ALTER TABLE anonymous_profile SET (
     autovacuum_vacuum_scale_factor = 0.05,

--- a/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_upgrade.sql
+++ b/db_upgrade_scripts/mosip_ida/sql/1.2.1.2_to_1.3.0_upgrade.sql
@@ -19,6 +19,7 @@ ALTER TABLE BATCH_JOB_EXECUTION DROP COLUMN JOB_CONFIGURATION_LOCATION;
 CREATE INDEX IF NOT EXISTS idx_job_name ON BATCH_JOB_INSTANCE(JOB_NAME);
 CREATE INDEX IF NOT EXISTS idx_job_key ON BATCH_JOB_INSTANCE(JOB_KEY);
 
+-- Below script required to upgraded from 1.3.0-beta.1 to 1.3.0
 --------ca_cert_store-upgrade-db script------------
 ALTER TABLE IF EXISTS ida.ca_cert_store ADD COLUMN ca_cert_type character varying(25);
 


### PR DESCRIPTION
[MOSIP-43787] Added index on credential_event_store for status filtering from v1.2.1.2 upgrade scripts, rollback & upgrade from 1.3.0-beta.1 to 1.3.0.

[MOSIP-43787]: https://mosip.atlassian.net/browse/MOSIP-43787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ