### PR TITLE
MOSIP-44494 - Updated the testclasses to capture timestamp for OTP's

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/AddIdentity.java
@@ -125,9 +125,7 @@ public class AddIdentity extends IdAuthenticationUtil implements ITest {
 			String picture = properties.getProperty("picturevalue");
 			list.add(picture);
 			attrmap.put("picture", list);
-			KeycloakUserManager.createVidUsers(IdAuthConfigManager.getproperty("new_Resident_User"),
-					IdAuthConfigManager.getproperty("new_Resident_Password"), IdAuthConfigManager.getproperty("new_Resident_Role"),
-					attrmap);
+			KeycloakUserManager.createVidUsers(IdAuthConfigManager.getproperty("new_Resident_User"), attrmap);
 		}
 
 		String jsonInput = testCaseDTO.getInput();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/MultiFactorAuthNew.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/MultiFactorAuthNew.java
@@ -17,8 +17,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.BaseTestMethod;
-import org.testng.internal.TestResult;
 
 import io.mosip.testrig.apirig.auth.utils.IdAuthConfigManager;
 import io.mosip.testrig.apirig.auth.utils.IdAuthenticationUtil;
@@ -30,6 +28,7 @@ import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.BioDataUtility;
 import io.mosip.testrig.apirig.utils.EncryptionDecrptionUtil;
+import io.mosip.testrig.apirig.utils.NotificationListener;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
@@ -123,6 +122,8 @@ public class MultiFactorAuthNew extends IdAuthenticationUtil implements ITest {
 		{
 			sendOtpEndPoint = sendOtpEndPoint.replace("$partnerKeyURL$", ekycPartnerKeyURL);
 		}
+		
+		NotificationListener.markRequestStart();
 		Response otpResponse = postRequestWithAuthHeaderAndSignature(ApplnURI + sendOtpEndPoint,
 				getJsonFromTemplate(otpReqJson.toString(), sendOtpReqTemplate), testCaseDTO.getTestCaseName());
 
@@ -231,6 +232,7 @@ public class MultiFactorAuthNew extends IdAuthenticationUtil implements ITest {
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
 		result.setAttribute("TestCaseName", testCaseName);
+	    NotificationListener.markRequestRemove();
 	}
 
 	@AfterClass

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/OtpAuthNew.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/OtpAuthNew.java
@@ -28,6 +28,7 @@ import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.EncryptionDecrptionUtil;
 import io.mosip.testrig.apirig.utils.FileUtil;
+import io.mosip.testrig.apirig.utils.NotificationListener;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.PartnerRegistration;
 import io.mosip.testrig.apirig.utils.ReportUtil;
@@ -125,6 +126,7 @@ public class OtpAuthNew extends IdAuthenticationUtil implements ITest {
 		}
 		
 		Response otpResponse = null;
+		NotificationListener.markRequestStart();
 		if(isInternal)
 			otpResponse = postRequestWithCookieAuthHeaderAndSignature(ApplnURI + sendOtpEndPoint, getJsonFromTemplate(otpReqJson.toString(), sendOtpReqTemplate), COOKIENAME, "resident", testCaseDTO.getTestCaseName());
 		else
@@ -193,6 +195,7 @@ public class OtpAuthNew extends IdAuthenticationUtil implements ITest {
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
 		result.setAttribute("TestCaseName", testCaseName);
+		NotificationListener.markRequestRemove();
 	}
 
 	@AfterClass

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PatchWithBodyWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PatchWithBodyWithOtpGenerate.java
@@ -28,6 +28,7 @@ import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.NotificationListener;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.SecurityXSSException;
@@ -101,6 +102,7 @@ public class PatchWithBodyWithOtpGenerate extends IdAuthenticationUtil implement
 		sendOtpEndPoint = otpReqJson.getString("sendOtpEndPoint");
 		otpReqJson.remove("sendOtpEndPoint");
 
+		NotificationListener.markRequestStart();
 		Response otpResponse = postWithBodyAndCookie(ApplnURI + sendOtpEndPoint,
 				getJsonFromTemplate(otpReqJson.toString(), sendOtpReqTemplate), COOKIENAME, GlobalConstants.RESIDENT,
 				testCaseDTO.getTestCaseName());
@@ -149,5 +151,6 @@ public class PatchWithBodyWithOtpGenerate extends IdAuthenticationUtil implement
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
 		result.setAttribute("TestCaseName", testCaseName);
+		NotificationListener.markRequestRemove();
 	}
 }

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -29,6 +29,7 @@ import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.NotificationListener;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.SecurityXSSException;
@@ -128,6 +129,7 @@ public class PostWithAutogenIdWithOtpGenerate extends IdAuthenticationUtil imple
 		int currLoopCount = 0;
 		while (currLoopCount < maxLoopCount) {
 			{
+				NotificationListener.markRequestStart();
 				otpResponse = postWithBodyAndCookie(ApplnURI + sendOtpEndPoint,
 						getJsonFromTemplate(otpReqJson.toString(), sendOtpReqTemplate), COOKIENAME,
 						GlobalConstants.RESIDENT, testCaseDTO.getTestCaseName());
@@ -203,6 +205,7 @@ public class PostWithAutogenIdWithOtpGenerate extends IdAuthenticationUtil imple
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
 		result.setAttribute("TestCaseName", testCaseName);
+		NotificationListener.markRequestRemove();
 	}
 
 	@AfterClass(alwaysRun = true)

--- a/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithBodyWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/auth/testscripts/PostWithBodyWithOtpGenerate.java
@@ -28,6 +28,7 @@ import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
+import io.mosip.testrig.apirig.utils.NotificationListener;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
 import io.mosip.testrig.apirig.utils.ReportUtil;
 import io.mosip.testrig.apirig.utils.SecurityXSSException;
@@ -108,6 +109,7 @@ public class PostWithBodyWithOtpGenerate extends IdAuthenticationUtil implements
 		int maxLoopCount = Integer.parseInt(properties.getProperty("uinGenMaxLoopCount"));
 		int currLoopCount = 0;
 		while (currLoopCount < maxLoopCount) {
+			NotificationListener.markRequestStart();
 			otpResponse = postWithBodyAndCookie(ApplnURI + sendOtpEndPoint,
 					getJsonFromTemplate(otpReqJson.toString(), sendOtpReqTemplate), COOKIENAME,
 					GlobalConstants.RESIDENT, testCaseDTO.getTestCaseName());
@@ -186,5 +188,6 @@ public class PostWithBodyWithOtpGenerate extends IdAuthenticationUtil implements
 	@AfterMethod(alwaysRun = true)
 	public void setResultTestName(ITestResult result) {
 		result.setAttribute("TestCaseName", testCaseName);
+		NotificationListener.markRequestRemove();
 	}
 }

--- a/api-test/src/main/resources/ida/UpdateIdentity/sendOtpRes.hbs
+++ b/api-test/src/main/resources/ida/UpdateIdentity/sendOtpRes.hbs
@@ -1,9 +1,4 @@
 {
   "id": "mosip.identity.otp",
-  "version": "1.0",
-  "transactionID": "{{transactionID}}",
-  "response": {
-   "maskedMobile": "{{maskedMobile}}",
-   "maskedEmail": "{{maskedEmail}}"
-  }
+  "version": "1.0"
 }


### PR DESCRIPTION
MOSIP-44494 - Updated the testclasses to capture timestamp for OTP's

- with this OTP's can be fetched as per the timestamps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified user creation API by reducing required parameters

* **Improvements**
  * Enhanced OTP authentication flows with request tracking capability
  * Streamlined OTP response structure with essential fields only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->