### PR TITLE
MOSIP-44691 Fixed maven build failure

### DIFF
--- a/authentication/authentication-internal-service/src/main/java/io/mosip/authentication/internal/service/InternalAuthenticationApplication.java
+++ b/authentication/authentication-internal-service/src/main/java/io/mosip/authentication/internal/service/InternalAuthenticationApplication.java
@@ -3,6 +3,7 @@ package io.mosip.authentication.internal.service;
 import io.mosip.authentication.common.service.helper.*;
 import io.mosip.authentication.common.service.integration.*;
 import io.mosip.authentication.common.service.util.*;
+import io.mosip.kernel.keymanagerservice.helper.SubjectAlternativeNamesHelper;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
 import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
 import io.mosip.kernel.websub.api.client.SubscriberClientImpl;
@@ -138,7 +139,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 		RestTemplateHelper.class, LanguageUtil.class, TypeForIdNameHelper.class
 		, ValidateOtpHelper.class, RequireOtpNotFrozenHelper.class, MatchIdentityDataHelper.class, MatchTypeHelper.class
 		, SeparatorHelper.class, IdentityAttributesForMatchTypeHelper.class, WebSubClientConfig.class, SubscriberClientImpl.class
-		, ECKeyPairGenRequestValidator.class, WebSubPublisherClientConfig.class
+		, ECKeyPairGenRequestValidator.class, WebSubPublisherClientConfig.class, SubjectAlternativeNamesHelper.class
 })
 @ComponentScan(basePackages = { "io.mosip.authentication.internal.service.*",
 		"io.mosip.kernel.core.logger.config",

--- a/authentication/authentication-internal-service/src/main/java/io/mosip/authentication/internal/service/InternalAuthenticationApplication.java
+++ b/authentication/authentication-internal-service/src/main/java/io/mosip/authentication/internal/service/InternalAuthenticationApplication.java
@@ -4,7 +4,7 @@ import io.mosip.authentication.common.service.helper.*;
 import io.mosip.authentication.common.service.integration.*;
 import io.mosip.authentication.common.service.util.*;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
-import io.mosip.kernel.pdfgenerator.itext.impl.PDFGeneratorImpl;
+import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
 import io.mosip.kernel.websub.api.client.SubscriberClientImpl;
 import io.mosip.kernel.websub.api.config.WebSubClientConfig;
 import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;

--- a/authentication/authentication-internal-service/src/main/java/io/mosip/authentication/internal/service/InternalAuthenticationApplication.java
+++ b/authentication/authentication-internal-service/src/main/java/io/mosip/authentication/internal/service/InternalAuthenticationApplication.java
@@ -6,6 +6,7 @@ import io.mosip.authentication.common.service.util.*;
 import io.mosip.kernel.keymanagerservice.helper.SubjectAlternativeNamesHelper;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
 import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
+import io.mosip.kernel.signature.util.SignatureUtil;
 import io.mosip.kernel.websub.api.client.SubscriberClientImpl;
 import io.mosip.kernel.websub.api.config.WebSubClientConfig;
 import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
@@ -139,7 +140,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 		RestTemplateHelper.class, LanguageUtil.class, TypeForIdNameHelper.class
 		, ValidateOtpHelper.class, RequireOtpNotFrozenHelper.class, MatchIdentityDataHelper.class, MatchTypeHelper.class
 		, SeparatorHelper.class, IdentityAttributesForMatchTypeHelper.class, WebSubClientConfig.class, SubscriberClientImpl.class
-		, ECKeyPairGenRequestValidator.class, WebSubPublisherClientConfig.class, SubjectAlternativeNamesHelper.class
+		, ECKeyPairGenRequestValidator.class, WebSubPublisherClientConfig.class, SubjectAlternativeNamesHelper.class, SignatureUtil.class
 })
 @ComponentScan(basePackages = { "io.mosip.authentication.internal.service.*",
 		"io.mosip.kernel.core.logger.config",

--- a/authentication/authentication-otp-service/src/main/java/io/mosip/authentication/otp/service/OtpApplication.java
+++ b/authentication/authentication-otp-service/src/main/java/io/mosip/authentication/otp/service/OtpApplication.java
@@ -1,6 +1,7 @@
 package io.mosip.authentication.otp.service;
 
 import io.mosip.authentication.common.service.config.*;
+import io.mosip.kernel.keymanagerservice.helper.SubjectAlternativeNamesHelper;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
 import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
 import io.mosip.kernel.websub.api.client.PublisherClientImpl;
@@ -116,7 +117,7 @@ import org.springframework.web.client.RestTemplate;
 		HSMHealthCheck.class, PrivateKeyDecryptorHelper.class,
 		PasswordAuthServiceImpl.class, PasswordComparator.class, AuthenticationErrorEventingPublisher.class, KafkaProducerConfig.class,
 		PDFGeneratorImpl.class, PublisherClientImpl.class, RestTemplateHelper.class,
-		SubscriberClientImpl.class, RestTemplate.class, ECKeyPairGenRequestValidator.class, TrailingSlashRedirectFilter.class})
+		SubscriberClientImpl.class, RestTemplate.class, ECKeyPairGenRequestValidator.class, TrailingSlashRedirectFilter.class, SubjectAlternativeNamesHelper.class})
 @ComponentScan(basePackages = { "io.mosip.authentication.otp.service.*",
 		"io.mosip.kernel.core.logger.config", "${mosip.auth.adapter.impl.basepackage}" }, excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = {
 				"io.mosip.idrepository.core.config.IdRepoDataSourceConfig.*" }))

--- a/authentication/authentication-otp-service/src/main/java/io/mosip/authentication/otp/service/OtpApplication.java
+++ b/authentication/authentication-otp-service/src/main/java/io/mosip/authentication/otp/service/OtpApplication.java
@@ -2,7 +2,7 @@ package io.mosip.authentication.otp.service;
 
 import io.mosip.authentication.common.service.config.*;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
-import io.mosip.kernel.pdfgenerator.itext.impl.PDFGeneratorImpl;
+import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
 import io.mosip.kernel.websub.api.client.PublisherClientImpl;
 import io.mosip.kernel.websub.api.client.SubscriberClientImpl;
 import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;

--- a/authentication/authentication-otp-service/src/main/java/io/mosip/authentication/otp/service/OtpApplication.java
+++ b/authentication/authentication-otp-service/src/main/java/io/mosip/authentication/otp/service/OtpApplication.java
@@ -4,6 +4,7 @@ import io.mosip.authentication.common.service.config.*;
 import io.mosip.kernel.keymanagerservice.helper.SubjectAlternativeNamesHelper;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
 import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
+import io.mosip.kernel.signature.util.SignatureUtil;
 import io.mosip.kernel.websub.api.client.PublisherClientImpl;
 import io.mosip.kernel.websub.api.client.SubscriberClientImpl;
 import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
@@ -117,7 +118,7 @@ import org.springframework.web.client.RestTemplate;
 		HSMHealthCheck.class, PrivateKeyDecryptorHelper.class,
 		PasswordAuthServiceImpl.class, PasswordComparator.class, AuthenticationErrorEventingPublisher.class, KafkaProducerConfig.class,
 		PDFGeneratorImpl.class, PublisherClientImpl.class, RestTemplateHelper.class,
-		SubscriberClientImpl.class, RestTemplate.class, ECKeyPairGenRequestValidator.class, TrailingSlashRedirectFilter.class, SubjectAlternativeNamesHelper.class})
+		SubscriberClientImpl.class, RestTemplate.class, ECKeyPairGenRequestValidator.class, TrailingSlashRedirectFilter.class, SubjectAlternativeNamesHelper.class, SignatureUtil.class})
 @ComponentScan(basePackages = { "io.mosip.authentication.otp.service.*",
 		"io.mosip.kernel.core.logger.config", "${mosip.auth.adapter.impl.basepackage}" }, excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = {
 				"io.mosip.idrepository.core.config.IdRepoDataSourceConfig.*" }))

--- a/authentication/authentication-service/pom.xml
+++ b/authentication/authentication-service/pom.xml
@@ -227,7 +227,7 @@
         <dependency>
             <groupId>io.mosip.biometric.util</groupId>
             <artifactId>biometrics-util</artifactId>
-            <version>${kernel-biometrics-util}</version>
+            <version>${kernel-biometrics-util.version}</version>
             <exclusions>
             	<exclusion>
             		<groupId>com.fasterxml.jackson.core</groupId>

--- a/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
+++ b/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
@@ -80,7 +80,7 @@ import io.mosip.kernel.tokenidgenerator.generator.TokenIDGenerator;
 import io.mosip.kernel.tokenidgenerator.service.impl.TokenIDGeneratorServiceImpl;
 import io.mosip.kernel.zkcryptoservice.service.impl.ZKCryptoManagerServiceImpl;
 import io.mosip.kernel.keymanager.hsm.health.HSMHealthCheck;
-import io.mosip.kernel.pdfgenerator.itext.impl.PDFGeneratorImpl;
+import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
 import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
 
 

--- a/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
+++ b/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
@@ -3,9 +3,9 @@ package io.mosip.authentication.service;
 import io.mosip.authentication.common.service.helper.*;
 import io.mosip.authentication.common.service.integration.*;
 import io.mosip.authentication.common.service.util.*;
-import io.mosip.kernel.core.pdfgenerator.spi.PDFGenerator;
 import io.mosip.kernel.keymanagerservice.helper.SubjectAlternativeNamesHelper;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
+import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -119,7 +119,7 @@ import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
 		RestTemplateHelper.class, LanguageUtil.class, IdentityAttributesForMatchTypeHelper.class
 , TypeForIdNameHelper.class
 		, ValidateOtpHelper.class, RequireOtpNotFrozenHelper.class, MatchIdentityDataHelper.class, MatchTypeHelper.class
-		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class, SubjectAlternativeNamesHelper.class, PDFGenerator.class})
+		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class, SubjectAlternativeNamesHelper.class, PDFGeneratorImpl.class})
 @ComponentScan(basePackages = { "io.mosip.authentication.service.*", "io.mosip.kernel.core.logger.config",
 		"io.mosip.authentication.common.service.config","io.mosip.authentication.common.service.util",
 		"io.mosip.kernel.websub.api.config",

--- a/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
+++ b/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
@@ -6,6 +6,7 @@ import io.mosip.authentication.common.service.util.*;
 import io.mosip.kernel.keymanagerservice.helper.SubjectAlternativeNamesHelper;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
 import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
+import io.mosip.kernel.signature.util.SignatureUtil;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -119,7 +120,7 @@ import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
 		RestTemplateHelper.class, LanguageUtil.class, IdentityAttributesForMatchTypeHelper.class
 , TypeForIdNameHelper.class
 		, ValidateOtpHelper.class, RequireOtpNotFrozenHelper.class, MatchIdentityDataHelper.class, MatchTypeHelper.class
-		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class, SubjectAlternativeNamesHelper.class, PDFGeneratorImpl.class})
+		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class, SubjectAlternativeNamesHelper.class, PDFGeneratorImpl.class, SignatureUtil.class})
 @ComponentScan(basePackages = { "io.mosip.authentication.service.*", "io.mosip.kernel.core.logger.config",
 		"io.mosip.authentication.common.service.config","io.mosip.authentication.common.service.util",
 		"io.mosip.kernel.websub.api.config",

--- a/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
+++ b/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
@@ -3,6 +3,7 @@ package io.mosip.authentication.service;
 import io.mosip.authentication.common.service.helper.*;
 import io.mosip.authentication.common.service.integration.*;
 import io.mosip.authentication.common.service.util.*;
+import io.mosip.kernel.keymanagerservice.helper.SubjectAlternativeNamesHelper;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -117,7 +118,7 @@ import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
 		RestTemplateHelper.class, LanguageUtil.class, IdentityAttributesForMatchTypeHelper.class
 , TypeForIdNameHelper.class
 		, ValidateOtpHelper.class, RequireOtpNotFrozenHelper.class, MatchIdentityDataHelper.class, MatchTypeHelper.class
-		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class})
+		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class, SubjectAlternativeNamesHelper.class})
 @ComponentScan(basePackages = { "io.mosip.authentication.service.*", "io.mosip.kernel.core.logger.config",
 		"io.mosip.authentication.common.service.config","io.mosip.authentication.common.service.util",
 		"io.mosip.kernel.websub.api.config",

--- a/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
+++ b/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
@@ -3,6 +3,7 @@ package io.mosip.authentication.service;
 import io.mosip.authentication.common.service.helper.*;
 import io.mosip.authentication.common.service.integration.*;
 import io.mosip.authentication.common.service.util.*;
+import io.mosip.kernel.core.pdfgenerator.spi.PDFGenerator;
 import io.mosip.kernel.keymanagerservice.helper.SubjectAlternativeNamesHelper;
 import io.mosip.kernel.keymanagerservice.validator.ECKeyPairGenRequestValidator;
 import org.springframework.boot.SpringApplication;
@@ -118,7 +119,7 @@ import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
 		RestTemplateHelper.class, LanguageUtil.class, IdentityAttributesForMatchTypeHelper.class
 , TypeForIdNameHelper.class
 		, ValidateOtpHelper.class, RequireOtpNotFrozenHelper.class, MatchIdentityDataHelper.class, MatchTypeHelper.class
-		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class, SubjectAlternativeNamesHelper.class})
+		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class, SubjectAlternativeNamesHelper.class, PDFGenerator.class})
 @ComponentScan(basePackages = { "io.mosip.authentication.service.*", "io.mosip.kernel.core.logger.config",
 		"io.mosip.authentication.common.service.config","io.mosip.authentication.common.service.util",
 		"io.mosip.kernel.websub.api.config",

--- a/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
+++ b/authentication/authentication-service/src/main/java/io/mosip/authentication/service/IdAuthenticationApplication.java
@@ -80,7 +80,6 @@ import io.mosip.kernel.tokenidgenerator.generator.TokenIDGenerator;
 import io.mosip.kernel.tokenidgenerator.service.impl.TokenIDGeneratorServiceImpl;
 import io.mosip.kernel.zkcryptoservice.service.impl.ZKCryptoManagerServiceImpl;
 import io.mosip.kernel.keymanager.hsm.health.HSMHealthCheck;
-import io.mosip.kernel.pdfgenerator.impl.PDFGeneratorImpl;
 import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
 
 
@@ -115,7 +114,7 @@ import io.mosip.kernel.websub.api.config.publisher.RestTemplateHelper;
 		HSMHealthCheck.class, TokenValidationHelper.class, VCSchemaProviderUtil.class, PrivateKeyDecryptorHelper.class, 
 		PasswordAuthServiceImpl.class, PasswordComparator.class, AuthenticationErrorEventingPublisher.class,
 		PasswordAuthServiceImpl.class, PasswordComparator.class, AuthenticationErrorEventingPublisher.class,
-		PDFGeneratorImpl.class, RestTemplateHelper.class, LanguageUtil.class, IdentityAttributesForMatchTypeHelper.class
+		RestTemplateHelper.class, LanguageUtil.class, IdentityAttributesForMatchTypeHelper.class
 , TypeForIdNameHelper.class
 		, ValidateOtpHelper.class, RequireOtpNotFrozenHelper.class, MatchIdentityDataHelper.class, MatchTypeHelper.class
 		, SeparatorHelper.class, ECKeyPairGenRequestValidator.class})

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -98,29 +98,29 @@
         <sonar.test.exclusions>src/test/resources/**,**/*.gitignore,**/git.properties</sonar.test.exclusions>
 
 		<!-- Kernel components -->
-		<kernel.parent.version>1.3.0-SNAPSHOT</kernel.parent.version>
-		<kernel-core.version>1.3.0-SNAPSHOT</kernel-core.version>
+		<kernel.parent.version>1.2.1-SNAPSHOT</kernel.parent.version>
+		<kernel-core.version>1.2.1-SNAPSHOT</kernel-core.version>
 		<kernel-keymanager-service.version>1.3.0-beta.1</kernel-keymanager-service.version>
-		<kernel-idgenerator-tokenid.version>1.3.0-SNAPSHOT</kernel-idgenerator-tokenid.version>
-		<kernel-idobjectvalidator.version>1.3.0-SNAPSHOT</kernel-idobjectvalidator.version>
+		<kernel-idgenerator-tokenid.version>1.2.1-SNAPSHOT</kernel-idgenerator-tokenid.version>
+		<kernel-idobjectvalidator.version>1.2.1-SNAPSHOT</kernel-idobjectvalidator.version>
 		<kernel-pinvalidator.version>1.2.1-SNAPSHOT</kernel-pinvalidator.version>
-		<kernel-templatemanager-velocity.version>1.3.0-SNAPSHOT</kernel-templatemanager-velocity.version>
-		<kernel-logger-logback.version>1.3.0-SNAPSHOT</kernel-logger-logback.version>
-		<kernel-dataaccess-hibernate.version>1.3.0-SNAPSHOT</kernel-dataaccess-hibernate.version>
-		<kernel-cbeffutil-api.version>1.3.0-SNAPSHOT</kernel-cbeffutil-api.version>
-		<kernel-templatemanager-velocity.version>1.3.0-SNAPSHOT</kernel-templatemanager-velocity.version>
+		<kernel-templatemanager-velocity.version>1.2.1-SNAPSHOT</kernel-templatemanager-velocity.version>
+		<kernel-logger-logback.version>1.2.1-SNAPSHOT</kernel-logger-logback.version>
+		<kernel-dataaccess-hibernate.version>1.2.1-SNAPSHOT</kernel-dataaccess-hibernate.version>
+		<kernel-cbeffutil-api.version>1.2.1-SNAPSHOT</kernel-cbeffutil-api.version>
+		<kernel-templatemanager-velocity.version>1.2.1-SNAPSHOT</kernel-templatemanager-velocity.version>
 		<kernel-auth-adapter.version>1.2.1-SNAPSHOT</kernel-auth-adapter.version>
-		<kernel-biometrics-api.version>1.3.0-SNAPSHOT</kernel-biometrics-api.version>
-		<kernel-biosdk-provider.version>1.3.0-SNAPSHOT</kernel-biosdk-provider.version>
-		<kernel-websubclient-api.version>1.3.0-SNAPSHOT</kernel-websubclient-api.version>
+		<kernel-biometrics-api.version>1.2.1-SNAPSHOT</kernel-biometrics-api.version>
+		<kernel-biosdk-provider.version>1.2.1-SNAPSHOT</kernel-biosdk-provider.version>
+		<kernel-websubclient-api.version>1.2.1-SNAPSHOT</kernel-websubclient-api.version>
 		<id-repository-core.version>1.2.1-SNAPSHOT</id-repository-core.version>
 		<json.utility.version>20180130</json.utility.version>
-		<kernel-demoapi.version>1.3.0-SNAPSHOT</kernel-demoapi.version>
-		<kernel-idauthenticationfilter-api.version>1.3.0-SNAPSHOT</kernel-idauthenticationfilter-api.version>
-		<kernel-biometrics-util>1.3.0-SNAPSHOT</kernel-biometrics-util>
-		<kernel-openid-bridge-api.version>1.3.0-SNAPSHOT</kernel-openid-bridge-api.version>
-		<kernel-bom.version>1.3.0-SNAPSHOT</kernel-bom.version>
-		<biosdk-client.version>1.3.0-SNAPSHOT</biosdk-client.version>
+		<kernel-demoapi.version>1.2.1-SNAPSHOT</kernel-demoapi.version>
+		<kernel-idauthenticationfilter-api.version>1.2.1-SNAPSHOT</kernel-idauthenticationfilter-api.version>
+		<kernel-biometrics-util>1.2.1-SNAPSHOT</kernel-biometrics-util>
+		<kernel-openid-bridge-api.version>1.2.1-SNAPSHOT</kernel-openid-bridge-api.version>
+		<kernel-bom.version>1.2.1-SNAPSHOT</kernel-bom.version>
+		<biosdk-client.version>1.2.1-SNAPSHOT</biosdk-client.version>
 		<demosdk.version>1.2.1-SNAPSHOT</demosdk.version>
 		<esignet-core.version>1.2.1-SNAPSHOT</esignet-core.version>
 

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -100,11 +100,10 @@
 		<!-- Kernel components -->
 		<kernel.parent.version>1.2.1-SNAPSHOT</kernel.parent.version>
 		<kernel-core.version>1.2.1-SNAPSHOT</kernel-core.version>
-		<kernel-keymanager-service.version>1.3.0-beta.1</kernel-keymanager-service.version>
+		<kernel-keymanager-service.version>1.2.1-SNAPSHOT</kernel-keymanager-service.version>
 		<kernel-idgenerator-tokenid.version>1.2.1-SNAPSHOT</kernel-idgenerator-tokenid.version>
 		<kernel-idobjectvalidator.version>1.2.1-SNAPSHOT</kernel-idobjectvalidator.version>
 		<kernel-pinvalidator.version>1.2.1-SNAPSHOT</kernel-pinvalidator.version>
-		<kernel-templatemanager-velocity.version>1.2.1-SNAPSHOT</kernel-templatemanager-velocity.version>
 		<kernel-logger-logback.version>1.2.1-SNAPSHOT</kernel-logger-logback.version>
 		<kernel-dataaccess-hibernate.version>1.2.1-SNAPSHOT</kernel-dataaccess-hibernate.version>
 		<kernel-cbeffutil-api.version>1.2.1-SNAPSHOT</kernel-cbeffutil-api.version>
@@ -117,7 +116,7 @@
 		<json.utility.version>20180130</json.utility.version>
 		<kernel-demoapi.version>1.2.1-SNAPSHOT</kernel-demoapi.version>
 		<kernel-idauthenticationfilter-api.version>1.2.1-SNAPSHOT</kernel-idauthenticationfilter-api.version>
-		<kernel-biometrics-util>1.2.1-SNAPSHOT</kernel-biometrics-util>
+		<kernel-biometrics-util.version>1.2.1-SNAPSHOT</kernel-biometrics-util.version>
 		<kernel-openid-bridge-api.version>1.2.1-SNAPSHOT</kernel-openid-bridge-api.version>
 		<kernel-bom.version>1.2.1-SNAPSHOT</kernel-bom.version>
 		<biosdk-client.version>1.2.1-SNAPSHOT</biosdk-client.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rolled back multiple core framework/kernel component versions for compatibility and stability.
  * Switched authentication services to a different PDF generator implementation.
  * Aligned a biometric utility dependency property and updated authentication startup registrations to match the revised versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->