### PR TITLE
Updated central-publishing-maven-plugin version from 0.7.0 to 0.11.0 to fix Nexus publish failure #403

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -69,7 +69,7 @@
 		<maven.shade.plugin.version>3.2.4</maven.shade.plugin.version>
 		<maven.antrun.plugin.version>3.0.0</maven.antrun.plugin.version>
 		<maven.source.plugin.version>2.2.1</maven.source.plugin.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
 
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
 		<fileName>apitest-auth-1.3.0-jar-with-dependencies</fileName>

--- a/authentication/authentication-authtypelockfilter-impl/pom.xml
+++ b/authentication/authentication-authtypelockfilter-impl/pom.xml
@@ -25,7 +25,7 @@
 		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>
 		<maven.javadoc.version>3.2.0</maven.javadoc.version>
 		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
 		<!-- spring -->
 		<spring.security.test.version>5.0.5.RELEASE</spring.security.test.version>
 

--- a/authentication/authentication-filter-api/pom.xml
+++ b/authentication/authentication-filter-api/pom.xml
@@ -27,7 +27,7 @@
 		<maven.war.plugin.version>3.1.0</maven.war.plugin.version>
 		<maven.javadoc.version>3.2.0</maven.javadoc.version>
 		<maven-shade-plugin.version>2.3</maven-shade-plugin.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
 		<!-- spring -->
 		<spring.security.test.version>5.0.5.RELEASE</spring.security.test.version>
 

--- a/authentication/authentication-hotlistfilter-impl/pom.xml
+++ b/authentication/authentication-hotlistfilter-impl/pom.xml
@@ -207,7 +207,7 @@
 		<aspectjweaver.version>1.8.12</aspectjweaver.version>
 		<micrometer.core.version>1.4.2</micrometer.core.version>
 		<micrometer.registry.prometheus.version>1.4.2</micrometer.registry.prometheus.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
 	</properties>
 
 		

--- a/authentication/authentication-internal-service/pom.xml
+++ b/authentication/authentication-internal-service/pom.xml
@@ -16,7 +16,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
 		<jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/authentication/authentication-otp-service/pom.xml
+++ b/authentication/authentication-otp-service/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
         <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
-        <central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+        <central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
     </properties>
     <dependencies>
         <dependency>

--- a/authentication/authentication-service/pom.xml
+++ b/authentication/authentication-service/pom.xml
@@ -18,7 +18,7 @@
     <properties>
     <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
         <jacoco.maven.plugin.version>0.8.11</jacoco.maven.plugin.version>
-        <central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+        <central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
     </properties>
     <dependencies>
         <dependency>

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -125,7 +125,7 @@
 		<powermock.version>2.0.9</powermock.version>
 		<maven.surefire.plugin.version>3.1.2</maven.surefire.plugin.version>
 		<jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
 		<!-- Test & Logging -->
 		<junit.version>4.13.2</junit.version>
 		<mockito.version>3.4.3</mockito.version>
@@ -136,7 +136,7 @@
 		<hibernate.validator.version>6.0.12.Final</hibernate.validator.version>
 		<postgresql.version>42.2.2</postgresql.version>
 		<spring-boot-maven-plugin.version>3.2.3</spring-boot-maven-plugin.version>
-		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
+		<central.publishing.maven.plugin.version>0.11.0</central.publishing.maven.plugin.version>
 		<!-- Commons -->
 		<commons.lang.version>3.7</commons.lang.version>
 		<commons.codec.version>1.11</commons.codec.version>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Maven Central publishing plugin to version 0.11.0 across the project’s build configurations.
  * Aligns publishing workflows across authentication modules and API testing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->