### PR TITLE
DSD-10748: fix internal OTP partner identity after service merge

### DIFF
--- a/authentication/authentication-common/src/main/java/io/mosip/authentication/common/service/impl/OTPServiceImpl.java
+++ b/authentication/authentication-common/src/main/java/io/mosip/authentication/common/service/impl/OTPServiceImpl.java
@@ -108,6 +108,10 @@ public class OTPServiceImpl implements OTPService {
 	
 	@Autowired
 	private IdAuthSecurityManager securityManager;
+
+	@Autowired
+	@Qualifier("internalAuthSecurityManager")
+	private IdAuthSecurityManager internalSecurityManager;
 	
 	@Autowired
 	private PartnerService partnerService;
@@ -309,7 +313,7 @@ public class OTPServiceImpl implements OTPService {
 				.withToken(token)
 				.withPartner(partner)
 				.withInternal(isInternal)
-				.build(env,uinHashSaltRepo,securityManager);
+				.build(env, uinHashSaltRepo, isInternal ? internalSecurityManager : securityManager);
 		fraudEventManager.analyseEvent(authTxn);
 		if(requestWithMetadata != null) {
 			requestWithMetadata.setMetadata(Map.of(AutnTxn.class.getSimpleName(), authTxn));	


### PR DESCRIPTION
Internal OTP requests can fail with `IDA-OTA-011` after the service merge: OTP transaction creation uses the primary security manager and stores the configured IDA client ID, while internal authentication validates against the authenticated caller identity. This blocks Resident VID creation and auth lock/unlock requests.

Inject `internalAuthSecurityManager` separately and use it only when building internal OTP transactions. External OTP transactions retain their existing security manager, and partner-ID validation is unchanged.

Validation:
- A temporary regression test reproduced `IDA-OTA-011` before the fix and passed unchanged after it. Additional temporary tests covered a different caller being rejected, usernames without the service-account prefix, and external OTP partner identity; these tests were removed after verification.
- Clean package build on this PR branch passed: 58 existing tests passed, 3 skipped, zero failures or errors.
- Environment API suite validation is pending deployment.

```sh
mvn -o -pl authentication-service -am clean package -Dtest=OTPServiceImplTest,OTPAuthServiceTest,AuthTransactionBuilderTest,InternalOTPControllerTest,InternalAuthControllerTest,OTPControllerTest -Dsurefire.failIfNoSpecifiedTests=false -DskipTests=false -Dmaven.javadoc.skip=true -Dgpg.skip=true -Dmaven.gitcommitid.skip=true
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OTP transaction processing for internal authentication requests.
  - Internal and external authentication flows now use the appropriate security handling, improving transaction reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->